### PR TITLE
Fix KeyError: add Course column to tiger5 by_round DataFrame

### DIFF
--- a/engines/tiger5.py
+++ b/engines/tiger5.py
@@ -208,6 +208,7 @@ def tiger5_by_round(df, hole_summary):
             'Round ID': rid,
             'Label': label,
             'Date': date_obj,
+            'Course': r['Course'],
             '3 Putts': f_3p,
             'Double Bogey': f_db,
             'Par 5 Bogey': f_p5,


### PR DESCRIPTION
The Tiger 5 Trend chart references t5_df['Course'] but the column was missing from the by_round output. Added it to the row dict.

https://claude.ai/code/session_01JJHm2p9boPcnJbaZJ8d5Bm