### PR TITLE
Enhance overview: hole outcome donut, scoring cards, styled SG pivot

### DIFF
--- a/engines/overview.py
+++ b/engines/overview.py
@@ -188,6 +188,32 @@ def build_scoring_by_par(hole_summary):
 
 
 # ============================================================
+# HOLE OUTCOME DISTRIBUTION
+# ============================================================
+
+def build_hole_outcomes(hole_summary):
+    """Count and percentage of each scoring outcome."""
+    if hole_summary.empty:
+        return pd.DataFrame()
+
+    score_order = ['Eagle', 'Birdie', 'Par', 'Bogey', 'Double or Worse']
+
+    counts = hole_summary['Score Name'].value_counts()
+    total = counts.sum()
+
+    rows = []
+    for name in score_order:
+        c = int(counts.get(name, 0))
+        rows.append({
+            'Score': name,
+            'Count': c,
+            'Pct': round(c / total * 100, 1) if total > 0 else 0
+        })
+
+    return pd.DataFrame(rows)
+
+
+# ============================================================
 # HOLE-BY-HOLE SG PIVOT BY SHOT TYPE
 # ============================================================
 


### PR DESCRIPTION
- Replace scoring table with two-column layout: hole outcome donut chart (left) showing Eagle/Birdie/Par/Bogey/Double distribution, and styled scoring cards (right) with overall + per-par scoring avg, total SG, and SG/hole
- Add build_hole_outcomes() engine function for outcome distribution
- Replace plain SG pivot dataframe with styled HTML table featuring conditional formatting (green for gains, red for losses), dark header row, and gold total row

https://claude.ai/code/session_01JJHm2p9boPcnJbaZJ8d5Bm