### PR TITLE
Revert SG separator cards back to sg-card format

### DIFF
--- a/app.py
+++ b/app.py
@@ -540,26 +540,28 @@ def strokes_gained_tab(
         # Row 1: first 4 cards
         row1 = st.columns(4)
         for col, (label, val, pr) in zip(row1, separators[:4]):
-            card_class = "tiger-card-fail" if val < 0 else "tiger-card-success"
+            val_class = sg_value_class(val)
             with col:
                 st.markdown(f"""
-                    <div class="{card_class}">
+                    <div class="sg-card">
                         <div class="card-label">{label}</div>
-                        <div class="card-value">{val:+.2f}</div>
-                        <div class="card-unit">{pr:+.2f} per round</div>
+                        <div class="card-value {val_class}">{val:+.2f}</div>
+                        <div style="font-family:Inter;font-size:0.7rem;color:#888;
+                             margin-top:0.3rem;">{pr:+.2f} per round</div>
                     </div>
                 """, unsafe_allow_html=True)
 
         # Row 2: remaining 3 cards
         row2 = st.columns(4)
         for col, (label, val, pr) in zip(row2, separators[4:]):
-            card_class = "tiger-card-fail" if val < 0 else "tiger-card-success"
+            val_class = sg_value_class(val)
             with col:
                 st.markdown(f"""
-                    <div class="{card_class}">
+                    <div class="sg-card">
                         <div class="card-label">{label}</div>
-                        <div class="card-value">{val:+.2f}</div>
-                        <div class="card-unit">{pr:+.2f} per round</div>
+                        <div class="card-value {val_class}">{val:+.2f}</div>
+                        <div style="font-family:Inter;font-size:0.7rem;color:#888;
+                             margin-top:0.3rem;">{pr:+.2f} per round</div>
                     </div>
                 """, unsafe_allow_html=True)
 


### PR DESCRIPTION
Only the SG summary hero cards should use the tiger-card format. The separator cards should remain as sg-card style, matching the Approach Performance by Distance cards.

https://claude.ai/code/session_019GxrqrSAhd4MnJ11PrHnWb