### PR TITLE
Split putt tracking into lag putts and short putts categories

### DIFF
--- a/app.py
+++ b/app.py
@@ -314,10 +314,10 @@ def tiger5_tab(filtered_df, hole_summary, tiger5_results, total_tiger5_fails):
         filtered_df, tiger5_results, hole_summary
     )
 
-    # 4 shot-type cards
-    rc_cols = st.columns(4)
-    rc_types = ['Driving', 'Approach', 'Short Game', 'Putt']
-    rc_colors = [ODU_GOLD, ODU_BLACK, ODU_GREEN, ODU_PURPLE]
+    # 5 shot-type cards
+    rc_cols = st.columns(5)
+    rc_types = ['Driving', 'Approach', 'Short Game', 'Short Putts', 'Lag Putts']
+    rc_colors = [ODU_GOLD, ODU_BLACK, ODU_GREEN, ODU_PURPLE, ODU_METALLIC_GOLD]
 
     for col, stype, color in zip(rc_cols, rc_types, rc_colors):
         count = shot_type_counts.get(stype, 0)
@@ -351,9 +351,9 @@ def tiger5_tab(filtered_df, hole_summary, tiger5_results, total_tiger5_fails):
                 other = len(items) - lag - short
                 parts = []
                 if lag:
-                    parts.append(f"Poor Lag Putt (left >5ft): **{lag}**")
+                    parts.append(f"Poor Lag Putt (left >=6ft): **{lag}**")
                 if short:
-                    parts.append(f"Missed Short Putt (<=5ft): **{short}**")
+                    parts.append(f"Missed Short Putt (<6ft): **{short}**")
                 if other:
                     parts.append(f"Other: **{other}**")
                 for p in parts:


### PR DESCRIPTION
## Summary
Refactored the Tiger 5 root cause analysis to distinguish between lag putts and short putts, providing more granular insights into putting performance. This change splits the single "Putt" category into two separate categories based on distance thresholds.

## Key Changes
- **UI Updates**: Expanded shot-type cards from 4 to 5 columns to display the new categories
  - Added "Short Putts" and "Lag Putts" as separate cards
  - Added `ODU_METALLIC_GOLD` color for the new Lag Putts card
  
- **Distance Threshold Logic**: Implemented 6-foot threshold to categorize putts
  - Short Putts: starting distance < 6 feet
  - Lag Putts: starting distance >= 6 feet
  - Updated display text to reflect the new threshold (e.g., "left >=6ft" for lag putts, "<6ft" for short putts)

- **Root Cause Mapping**: Updated `build_tiger5_root_cause()` function to:
  - Remove "Putt" from the category mapping
  - Categorize putts based on starting distance for all Tiger 5 failure types (3 Putts, Double Bogey, Par 5 Bogey)
  - Apply distance-based logic consistently across different failure scenarios

## Implementation Details
- The 6-foot threshold is applied when determining putt category from the first putt's ending distance (for 3-putt analysis) or the worst putt's starting distance (for other failure types)
- Handles edge cases with `pd.notna()` checks to ensure valid distance data before comparison
- Maintains backward compatibility with existing shot type counting logic

https://claude.ai/code/session_01UdFyLkPK2D6ADtDBP1ek6D