### PR TITLE
Revise palette to deep forest green, remove all dark/black backgrounds

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,7 +1,7 @@
 [theme]
 base = "light"
-primaryColor = "#3B82F6"
-backgroundColor = "#FAFAFA"
-secondaryBackgroundColor = "#F0F0F0"
-textColor = "#2B2B2B"
+primaryColor = "#3D5A3E"
+backgroundColor = "#F8F7F4"
+secondaryBackgroundColor = "#F2F0EC"
+textColor = "#333333"
 font = "sans serif"

--- a/tabs/approach.py
+++ b/tabs/approach.py
@@ -9,7 +9,7 @@ import plotly.express as px
 import plotly.graph_objects as go
 
 from ui.theme import (
-    CHARCOAL, SLATE, ACCENT_PRIMARY, ACCENT_SECONDARY,
+    CHARCOAL, SLATE, WHITE, ACCENT_PRIMARY, ACCENT_SECONDARY,
     POSITIVE, NEGATIVE, BORDER_LIGHT,
     THRESHOLDS,
 )
@@ -91,10 +91,10 @@ def approach_tab(approach, num_rounds):
 
         with col:
             st.markdown(f'''
-                <div style="background:#fff;border-radius:12px;
+                <div style="background:{WHITE};border-radius:12px;
                      padding:1.25rem 1rem;text-align:center;
                      box-shadow:0 2px 8px rgba(0,0,0,0.06);
-                     border:1px solid #e2e2e2;margin-bottom:1rem;{border_style}">
+                     border:1px solid {BORDER_LIGHT};margin-bottom:1rem;{border_style}">
                     <div style="font-family:Inter,sans-serif;font-size:0.7rem;
                          font-weight:600;color:{SLATE};text-transform:uppercase;
                          letter-spacing:0.08em;margin-bottom:0.5rem;">
@@ -134,10 +134,10 @@ def approach_tab(approach, num_rounds):
 
         with col:
             st.markdown(f'''
-                <div style="background:#fff;border-radius:12px;
+                <div style="background:{WHITE};border-radius:12px;
                      padding:1.25rem 1rem;text-align:center;
                      box-shadow:0 2px 8px rgba(0,0,0,0.06);
-                     border:1px solid #e2e2e2;margin-bottom:1rem;{border_style}">
+                     border:1px solid {BORDER_LIGHT};margin-bottom:1rem;{border_style}">
                     <div style="font-family:Inter,sans-serif;font-size:0.7rem;
                          font-weight:600;color:{SLATE};text-transform:uppercase;
                          letter-spacing:0.08em;margin-bottom:0.5rem;">
@@ -154,7 +154,7 @@ def approach_tab(approach, num_rounds):
 
     # Best / worst legend
     st.markdown(
-        f'<p style="font-family:Inter,sans-serif;font-size:0.7rem;color:#999;'
+        f'<p style="font-family:Inter,sans-serif;font-size:0.7rem;color:{SLATE};'
         f'margin-top:0.5rem;">'
         f'<span style="color:{POSITIVE};">\u25aa</span> Best Total SG &nbsp;&nbsp;'
         f'<span style="color:{NEGATIVE};">\u25aa</span> Worst Total SG</p>',
@@ -262,7 +262,7 @@ def approach_tab(approach, num_rounds):
                     text=f"{sg_val:+.2f}<br><span style='font-size:10px'>"
                          f"({cnt_val})</span>",
                     showarrow=False,
-                    font=dict(family='Inter', size=12, color='#000'),
+                    font=dict(family='Inter', size=12, color=CHARCOAL),
                 ))
 
         fig_heat = px.imshow(

--- a/tabs/short_game.py
+++ b/tabs/short_game.py
@@ -8,7 +8,7 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
 from ui.theme import (
-    CHARCOAL, ACCENT_PRIMARY, POSITIVE, NEGATIVE,
+    CHARCOAL, WHITE, ACCENT_PRIMARY, POSITIVE, NEGATIVE,
     BORDER_LIGHT, THRESHOLDS,
 )
 from ui.chart_config import CHART_LAYOUT, SG_HEATMAP_COLORSCALE
@@ -104,7 +104,7 @@ def short_game_tab(sg, num_rounds):
             y=sg_pivot.index.tolist(),
             text=text_vals,
             texttemplate="%{text}",
-            textfont=dict(size=14, color="#ffffff"),
+            textfont=dict(size=14, color=WHITE),
             colorscale=SG_HEATMAP_COLORSCALE,
             zmid=0,
             colorbar=dict(title="SG/Shot"),

--- a/tabs/strokes_gained.py
+++ b/tabs/strokes_gained.py
@@ -158,12 +158,12 @@ def strokes_gained_tab(
                 label_style = (
                     f'font-weight:500;color:{CHARCOAL};font-size:0.72rem;'
                     f'padding:0.4rem 0.25rem;text-align:left;'
-                    f'border-bottom:1px solid #f0f0f0;position:sticky;left:0;'
+                    f'border-bottom:1px solid {BORDER_LIGHT};position:sticky;left:0;'
                     f'background:{WHITE};width:{label_w};'
                 )
                 cell_base = (
                     'font-size:0.72rem;padding:0.4rem 0.15rem;'
-                    'text-align:center;border-bottom:1px solid #f0f0f0;'
+                    f'text-align:center;border-bottom:1px solid {BORDER_LIGHT};'
                 )
 
             html += f'<tr style="{row_bg}">'
@@ -267,7 +267,7 @@ def strokes_gained_tab(
                 labels=chart_data['Score'],
                 values=chart_data['Count'],
                 hole=0.6,
-                marker_colors=[OUTCOME_COLORS.get(s, '#999')
+                marker_colors=[OUTCOME_COLORS.get(s, SLATE)
                                for s in chart_data['Score']],
                 textinfo='label+percent',
                 textposition='outside',
@@ -302,16 +302,17 @@ def strokes_gained_tab(
 
             sg_color = POSITIVE if overall_sg >= 0 else NEGATIVE
             st.markdown(f'''
-                <div style="background:linear-gradient(135deg,{CHARCOAL} 0%,{CHARCOAL_LIGHT} 100%);
-                     border-radius:12px;padding:1rem 1.25rem;
-                     border:2px solid {ACCENT_PRIMARY};margin-bottom:0.75rem;
+                <div style="background:{WHITE};border-radius:12px;
+                     padding:1rem 1.25rem;
+                     border:1px solid {BORDER_LIGHT};border-left:4px solid {ACCENT_PRIMARY};
+                     box-shadow:0 2px 8px rgba(0,0,0,0.06);margin-bottom:0.75rem;
                      display:flex;justify-content:space-between;align-items:center;">
                     <div>
                         <div style="font-family:{FONT_BODY};font-size:0.7rem;font-weight:600;
                              color:{ACCENT_PRIMARY};text-transform:uppercase;
                              letter-spacing:0.08em;">Overall</div>
                         <div style="font-family:{FONT_HEADING};font-size:1.8rem;
-                             font-weight:700;color:{ACCENT_PRIMARY};line-height:1.1;">
+                             font-weight:700;color:{CHARCOAL};line-height:1.1;">
                             {overall_avg:.2f}</div>
                         <div style="font-family:{FONT_BODY};font-size:0.65rem;
                              color:{SLATE};">Scoring Avg</div>
@@ -353,7 +354,7 @@ def strokes_gained_tab(
                                  text-transform:uppercase;
                                  letter-spacing:0.06em;">
                                 Par {par_val}
-                                <span style="color:#bbb;font-weight:400;">
+                                <span style="color:{SLATE};font-weight:400;">
                                     &middot; {holes_n} holes</span></div>
                             <div style="font-family:{FONT_HEADING};
                                  font-size:1.5rem;font-weight:700;
@@ -362,20 +363,20 @@ def strokes_gained_tab(
                                 <span style="font-size:0.8rem;color:{SLATE};">
                                     ({vs_par:+.2f})</span></div>
                             <div style="font-family:{FONT_BODY};font-size:0.6rem;
-                                 color:#aaa;">Scoring Avg (vs Par)</div>
+                                 color:{SLATE};">Scoring Avg (vs Par)</div>
                         </div>
                         <div style="text-align:right;">
                             <div style="font-family:{FONT_HEADING};
                                  font-size:1.2rem;font-weight:700;
                                  color:{sg_color_p};">{t_sg:+.2f}</div>
                             <div style="font-family:{FONT_BODY};font-size:0.6rem;
-                                 color:#aaa;">Total SG</div>
+                                 color:{SLATE};">Total SG</div>
                             <div style="font-family:{FONT_HEADING};
                                  font-size:0.95rem;font-weight:600;
                                  color:{sg_color_p};margin-top:0.15rem;">
                                 {sg_h:+.2f}</div>
                             <div style="font-family:{FONT_BODY};font-size:0.6rem;
-                                 color:#aaa;">SG / Hole</div>
+                                 color:{SLATE};">SG / Hole</div>
                         </div>
                     </div>
                 ''', unsafe_allow_html=True)

--- a/ui/chart_config.py
+++ b/ui/chart_config.py
@@ -3,7 +3,7 @@
 # ============================================================
 
 from ui.theme import (
-    WHITE, CHARCOAL, BORDER_LIGHT, POSITIVE, POSITIVE_BG,
+    WHITE, CHARCOAL, BORDER_LIGHT, WARM_GRAY, POSITIVE, POSITIVE_BG,
     POSITIVE_TEXT, NEGATIVE, NEGATIVE_BG, NEGATIVE_TEXT,
     FONT_BODY, THRESHOLDS,
 )
@@ -52,17 +52,17 @@ def sg_cell_style(val):
     if v > strong:
         return f"background:{POSITIVE_BG};color:{POSITIVE_TEXT};font-weight:600;"
     if v > 0:
-        return f"background:#E8F5E9;color:{POSITIVE};"
+        return f"background:{POSITIVE_BG};color:{POSITIVE};"
     if v < -strong:
         return f"background:{NEGATIVE_BG};color:{NEGATIVE_TEXT};font-weight:600;"
     if v < 0:
-        return f"background:#FCE4EC;color:{NEGATIVE};"
+        return f"background:{NEGATIVE_BG};color:{NEGATIVE};"
     return f"color:{CHARCOAL};"
 
 
 # Diverging heatmap colorscale centred on zero
 SG_HEATMAP_COLORSCALE = [
     [0.0, NEGATIVE],
-    [0.5, "#f5f5f5"],
+    [0.5, WARM_GRAY],
     [1.0, POSITIVE],
 ]

--- a/ui/components.py
+++ b/ui/components.py
@@ -2,12 +2,13 @@
 # SHARED UI COMPONENTS
 # ============================================================
 # Reusable, themeable building blocks for every tab.
+# Light, airy aesthetic — white cards with subtle borders.
 # ============================================================
 
 import streamlit as st
 from ui.theme import (
     CHARCOAL, CHARCOAL_LIGHT, SLATE, WHITE, BORDER_LIGHT,
-    ACCENT_PRIMARY, ACCENT_SECONDARY, ACCENT_MUTED,
+    ACCENT_PRIMARY, ACCENT_SECONDARY, ACCENT_MUTED, ACCENT_PALE,
     POSITIVE, NEGATIVE, NEUTRAL, WARNING,
     FONT_HEADING, FONT_BODY, CARD_RADIUS, CARD_PADDING,
     THRESHOLDS,
@@ -39,21 +40,25 @@ _SENTIMENT_COLORS = {
 
 def premium_hero_card(label, value, unit="", sentiment="neutral"):
     """
-    Dark-background hero metric card with coloured border + text.
+    Light-background hero metric card with coloured left border.
+
+    White card with a 3px left accent border for sentiment.
+    Clean, muted, premium feel — no dark backgrounds.
 
     sentiment: "positive" | "negative" | "neutral" | "accent" | "warning"
     """
     color = _SENTIMENT_COLORS.get(sentiment, ACCENT_PRIMARY)
     st.markdown(f'''
-        <div style="background:linear-gradient(135deg,{CHARCOAL} 0%,{CHARCOAL_LIGHT} 100%);
+        <div style="background:{WHITE};
              border-radius:{CARD_RADIUS};padding:{CARD_PADDING};text-align:center;
-             border:2px solid {color};margin-bottom:1rem;">
-            <div style="font-family:{FONT_BODY};font-size:0.7rem;font-weight:600;
-                 color:{color};text-transform:uppercase;letter-spacing:0.08em;
+             border:1px solid {BORDER_LIGHT};border-left:4px solid {color};
+             box-shadow:0 1px 4px rgba(0,0,0,0.04);margin-bottom:1rem;">
+            <div style="font-family:{FONT_BODY};font-size:0.65rem;font-weight:600;
+                 color:{SLATE};text-transform:uppercase;letter-spacing:0.08em;
                  margin-bottom:0.5rem;">{label}</div>
-            <div style="font-family:{FONT_HEADING};font-size:2.25rem;font-weight:700;
+            <div style="font-family:{FONT_HEADING};font-size:2.1rem;font-weight:700;
                  color:{color};line-height:1;margin-bottom:0.25rem;">{value}</div>
-            <div style="font-family:{FONT_BODY};font-size:0.65rem;
+            <div style="font-family:{FONT_BODY};font-size:0.6rem;
                  color:{SLATE};text-transform:uppercase;
                  letter-spacing:0.05em;">{unit}</div>
         </div>
@@ -77,14 +82,14 @@ def premium_stat_card(label, value, subtitle="", sentiment="neutral"):
     st.markdown(f'''
         <div style="background:{WHITE};border-radius:{CARD_RADIUS};
              padding:{CARD_PADDING};text-align:center;
-             box-shadow:0 2px 8px rgba(0,0,0,0.06);
+             box-shadow:0 1px 4px rgba(0,0,0,0.04);
              border:1px solid {BORDER_LIGHT};margin-bottom:1rem;">
-            <div style="font-family:{FONT_BODY};font-size:0.7rem;font-weight:600;
+            <div style="font-family:{FONT_BODY};font-size:0.65rem;font-weight:600;
                  color:{SLATE};text-transform:uppercase;letter-spacing:0.08em;
                  margin-bottom:0.5rem;">{label}</div>
             <div style="font-family:{FONT_HEADING};font-size:2rem;font-weight:700;
                  color:{value_color};line-height:1;">{value}</div>
-            <div style="font-family:{FONT_BODY};font-size:0.7rem;color:{SLATE};
+            <div style="font-family:{FONT_BODY};font-size:0.65rem;color:{SLATE};
                  margin-top:0.3rem;">{subtitle}</div>
         </div>
     ''', unsafe_allow_html=True)
@@ -130,7 +135,7 @@ def sidebar_title(text):
     st.markdown(
         f'<p style="font-family:{FONT_HEADING};font-size:1.4rem;font-weight:600;'
         f'color:{ACCENT_PRIMARY};margin-bottom:0.5rem;padding-bottom:1rem;'
-        f'border-bottom:1px solid #444;">{text}</p>',
+        f'border-bottom:1px solid {BORDER_LIGHT};">{text}</p>',
         unsafe_allow_html=True,
     )
 
@@ -138,7 +143,7 @@ def sidebar_title(text):
 def sidebar_label(text):
     st.markdown(
         f'<p style="font-family:{FONT_BODY};font-size:0.75rem;font-weight:500;'
-        f'color:{ACCENT_MUTED};text-transform:uppercase;letter-spacing:0.08em;'
+        f'color:{ACCENT_SECONDARY};text-transform:uppercase;letter-spacing:0.08em;'
         f'margin-bottom:0.5rem;margin-top:1.25rem;">{text}</p>',
         unsafe_allow_html=True,
     )

--- a/ui/css.py
+++ b/ui/css.py
@@ -6,14 +6,15 @@ import streamlit as st
 from ui.theme import (
     CHARCOAL, CHARCOAL_LIGHT, SLATE, WHITE, OFF_WHITE, WARM_GRAY,
     BORDER_LIGHT, ACCENT_PRIMARY, ACCENT_SECONDARY, ACCENT_MUTED,
-    POSITIVE, NEGATIVE, FONT_HEADING, FONT_BODY, CARD_RADIUS,
+    ACCENT_PALE, POSITIVE, NEGATIVE,
+    FONT_HEADING, FONT_BODY, CARD_RADIUS,
 )
 
 _CSS = f"""
 <style>
     @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;600;700&family=Inter:wght@300;400;500;600&display=swap');
 
-    .stApp {{ background: linear-gradient(180deg, {OFF_WHITE} 0%, #f5f5f5 100%); }}
+    .stApp {{ background: {OFF_WHITE}; }}
     #MainMenu {{visibility: hidden;}}
     footer {{visibility: hidden;}}
 
@@ -28,12 +29,17 @@ _CSS = f"""
     .main-subtitle {{
         font-family: {FONT_BODY}; font-size: 1rem; color: {SLATE};
         font-weight: 400; margin-bottom: 2rem; padding-bottom: 1.5rem;
-        border-bottom: 3px solid {ACCENT_PRIMARY};
+        border-bottom: 2px solid {ACCENT_PRIMARY};
     }}
 
-    /* ---- Sidebar ---- */
+    /* ---- Sidebar (light, warm) ---- */
     section[data-testid="stSidebar"] {{
-        background: linear-gradient(180deg, #0a0a0a 0%, #1a1a1a 100%);
+        background: {WARM_GRAY};
+        border-right: 1px solid {BORDER_LIGHT};
+    }}
+    section[data-testid="stSidebar"] .stMarkdown p,
+    section[data-testid="stSidebar"] .stMarkdown div {{
+        color: {CHARCOAL};
     }}
 
     /* ---- Data tables ---- */
@@ -51,14 +57,14 @@ _CSS = f"""
     /* ---- Expanders ---- */
     .streamlit-expanderHeader {{
         font-family: {FONT_BODY} !important; font-weight: 500 !important;
-        font-size: 0.9rem !important; background-color: #f8f8f8 !important;
+        font-size: 0.9rem !important; background-color: {WARM_GRAY} !important;
         border-radius: 8px !important;
     }}
 
     /* ---- Charts container ---- */
     .stPlotlyChart {{
         background: {WHITE}; border-radius: {CARD_RADIUS};
-        padding: 1rem; box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+        padding: 1rem; box-shadow: 0 1px 4px rgba(0,0,0,0.04);
         border: 1px solid {BORDER_LIGHT};
     }}
 
@@ -67,7 +73,7 @@ _CSS = f"""
         width: 100%; border-collapse: separate; border-spacing: 0;
         font-family: {FONT_BODY}; background: {WHITE};
         border-radius: {CARD_RADIUS}; overflow: hidden;
-        box-shadow: 0 4px 16px rgba(0,0,0,0.08);
+        box-shadow: 0 2px 8px rgba(0,0,0,0.06);
     }}
     .premium-table th {{
         background: {WARM_GRAY}; color: {CHARCOAL}; font-weight: 600;
@@ -78,41 +84,47 @@ _CSS = f"""
     .premium-table th:first-child {{ text-align: left; padding-left: 1.25rem; }}
     .premium-table td {{
         padding: 0.75rem; text-align: center;
-        border-bottom: 1px solid #f0f0f0; font-size: 0.9rem; color: {CHARCOAL};
+        border-bottom: 1px solid {BORDER_LIGHT}; font-size: 0.9rem;
+        color: {CHARCOAL};
     }}
     .premium-table td:first-child {{ text-align: left; padding-left: 1.25rem; font-weight: 500; }}
     .premium-table tr:last-child td {{ border-bottom: none; }}
-    .premium-table .row-primary {{ background: #f8f8f8; }}
+    .premium-table .row-primary {{ background: {WARM_GRAY}; }}
     .premium-table .row-primary td {{ font-weight: 600; font-size: 1rem; padding: 1rem 0.75rem; }}
-    .premium-table .row-header {{ background: #f0ede5; }}
+    .premium-table .row-header {{ background: {ACCENT_PALE}; }}
     .premium-table .row-header td {{
         color: {SLATE}; font-weight: 600; font-size: 0.7rem;
         text-transform: uppercase; letter-spacing: 0.05em; padding: 0.6rem 0.75rem;
     }}
     .premium-table .row-highlight {{
-        background: linear-gradient(90deg, {ACCENT_PRIMARY} 0%, {ACCENT_SECONDARY} 100%);
+        background: {ACCENT_PALE};
     }}
-    .premium-table .row-highlight td {{ font-weight: 700; color: {WHITE}; padding: 0.875rem 0.75rem; }}
+    .premium-table .row-highlight td {{ font-weight: 700; color: {ACCENT_PRIMARY}; padding: 0.875rem 0.75rem; }}
     .premium-table .row-danger {{
-        background: linear-gradient(90deg, {NEGATIVE} 0%, #b91c1c 100%);
+        background: {NEGATIVE_BG};
     }}
-    .premium-table .row-danger td {{ font-weight: 700; color: {WHITE}; padding: 0.875rem 0.75rem; }}
+    .premium-table .row-danger td {{ font-weight: 700; color: {NEGATIVE}; padding: 0.875rem 0.75rem; }}
     .premium-table .indent {{ padding-left: 2rem !important; }}
 
     /* ---- Tabs ---- */
     .stTabs [data-baseweb="tab-list"] {{ gap: 8px; }}
     .stTabs [data-baseweb="tab"] {{
-        height: 50px; background-color: #f0f0f0; border-radius: 8px 8px 0 0;
+        height: 50px; background-color: {WARM_GRAY}; border-radius: 8px 8px 0 0;
         padding: 0 24px; font-family: {FONT_BODY}; font-weight: 500;
-        color: {CHARCOAL} !important;
+        color: {CHARCOAL} !important; border: 1px solid {BORDER_LIGHT};
+        border-bottom: none;
     }}
-    .stTabs [data-baseweb="tab"]:hover {{ background-color: #ddd; }}
+    .stTabs [data-baseweb="tab"]:hover {{ background-color: {ACCENT_PALE}; }}
     .stTabs [aria-selected="true"] {{
-        background-color: {ACCENT_PRIMARY} !important;
-        color: {WHITE} !important; font-weight: 600 !important;
+        background-color: {WHITE} !important;
+        color: {ACCENT_PRIMARY} !important; font-weight: 600 !important;
+        border-bottom: 2px solid {ACCENT_PRIMARY} !important;
     }}
 </style>
 """
+
+# Need NEGATIVE_BG from theme — import it
+from ui.theme import NEGATIVE_BG
 
 
 def inject_css():

--- a/ui/theme.py
+++ b/ui/theme.py
@@ -1,43 +1,44 @@
 # ============================================================
-# DESIGN TOKENS — PREMIUM NEUTRAL PALETTE
+# DESIGN TOKENS — PREMIUM GREEN PALETTE
 # ============================================================
-# Single source of truth for all visual constants.
-# No school-specific colors. Neutral, sophisticated, timeless.
+# Inspired by private golf club aesthetics: clean whites,
+# deep olive/forest greens, warm grays, elegant serif headings.
 # ============================================================
 
 # --- PRIMARY PALETTE ---
-CHARCOAL       = "#2B2B2B"
-CHARCOAL_LIGHT = "#3D3D3D"
-SLATE          = "#64748B"
+CHARCOAL       = "#333333"     # text color — warm dark gray (not black)
+CHARCOAL_LIGHT = "#555555"     # secondary text
+SLATE          = "#6B7280"     # muted labels
 WHITE          = "#FFFFFF"
-OFF_WHITE      = "#FAFAFA"
-WARM_GRAY      = "#F5F3F0"
-BORDER_LIGHT   = "#E2E2E2"
-BORDER_MEDIUM  = "#D1D5DB"
+OFF_WHITE      = "#F8F7F4"     # warm off-white page background
+WARM_GRAY      = "#F2F0EC"     # card/table header backgrounds
+BORDER_LIGHT   = "#E0DDD7"     # warm light border
+BORDER_MEDIUM  = "#C9C5BC"     # medium border
 
-# --- ACCENT COLORS ---
-ACCENT_PRIMARY   = "#3B82F6"   # vivid blue — primary accent
-ACCENT_SECONDARY = "#6366F1"   # indigo — secondary accent
-ACCENT_MUTED     = "#93C5FD"   # light blue for subtle highlights
+# --- ACCENT COLORS (deep olive/forest green) ---
+ACCENT_PRIMARY   = "#3D5A3E"   # deep forest green — primary accent
+ACCENT_SECONDARY = "#5A7A5C"   # medium sage — secondary accent
+ACCENT_MUTED     = "#8FA890"   # light sage for subtle highlights
+ACCENT_PALE      = "#E8EDE8"   # very pale green for card backgrounds
 
 # --- SEMANTIC / CONDITIONAL FORMATTING COLORS ---
-POSITIVE       = "#059669"     # emerald green
+POSITIVE       = "#2D6A4F"     # deep green (positive SG / good)
 POSITIVE_BG    = "#D1FAE5"     # light green cell background
 POSITIVE_TEXT  = "#065F46"     # dark green cell text
-NEGATIVE       = "#DC2626"     # red
-NEGATIVE_BG    = "#FEE2E2"     # light red cell background
-NEGATIVE_TEXT  = "#991B1B"     # dark red cell text
+NEGATIVE       = "#C53030"     # muted red (negative SG / bad)
+NEGATIVE_BG    = "#FED7D7"     # light red cell background
+NEGATIVE_TEXT  = "#9B2C2C"     # dark red cell text
 NEUTRAL        = "#6B7280"     # gray for zero/neutral values
-WARNING        = "#F59E0B"     # amber for caution states
+WARNING        = "#B7791F"     # muted amber for caution states
 
 # --- CHART CATEGORY COLORS ---
 CHART_PALETTE = [
-    "#3B82F6",  # blue
-    "#2B2B2B",  # charcoal
-    "#059669",  # green
-    "#8B5CF6",  # violet
-    "#DC2626",  # red
-    "#F59E0B",  # amber
+    "#3D5A3E",  # deep green (driving)
+    "#8B6F47",  # warm brown (approach)
+    "#2D6A4F",  # forest green (short game)
+    "#7C6F9B",  # muted violet (putting)
+    "#C53030",  # muted red (fail/recovery)
+    "#B7791F",  # muted amber (secondary)
 ]
 
 CHART_DRIVING    = CHART_PALETTE[0]
@@ -49,21 +50,21 @@ CHART_SECONDARY  = CHART_PALETTE[5]
 
 # --- DONUT / OUTCOME CHART COLORS ---
 OUTCOME_COLORS = {
-    "Eagle":            "#F59E0B",
-    "Birdie":           "#059669",
-    "Par":              "#2B2B2B",
-    "Bogey":            "#DC2626",
-    "Double or Worse":  "#8B5CF6",
+    "Eagle":            "#B7791F",
+    "Birdie":           "#2D6A4F",
+    "Par":              "#3D5A3E",
+    "Bogey":            "#C53030",
+    "Double or Worse":  "#7C6F9B",
 }
 
-DONUT_SEQUENCE = ["#059669", "#3B82F6", "#F59E0B", "#DC2626"]
+DONUT_SEQUENCE = ["#2D6A4F", "#3D5A3E", "#B7791F", "#C53030"]
 
 # --- TYPOGRAPHY ---
 FONT_HEADING = "'Playfair Display', Georgia, serif"
 FONT_BODY    = "'Inter', -apple-system, BlinkMacSystemFont, sans-serif"
 
 # --- SPACING ---
-CARD_RADIUS  = "12px"
+CARD_RADIUS  = "10px"
 CARD_PADDING = "1.25rem 1rem"
 SECTION_GAP  = "2.5rem"
 


### PR DESCRIPTION
Replace blue primary (#3B82F6) with deep forest green (#3D5A3E). Remove all dark gradient backgrounds and hardcoded hex values across tabs and UI files. Hero cards now use white backgrounds with colored left-border accents. Sidebar is light warm gray instead of black. All colors now flow from centralized theme tokens in ui/theme.py.

https://claude.ai/code/session_01R5F2tJ52muwFi6pdcjA4CD