### PR TITLE
Fix NameError: move NEGATIVE_BG import before f-string evaluation

### DIFF
--- a/ui/css.py
+++ b/ui/css.py
@@ -6,7 +6,7 @@ import streamlit as st
 from ui.theme import (
     CHARCOAL, CHARCOAL_LIGHT, SLATE, WHITE, OFF_WHITE, WARM_GRAY,
     BORDER_LIGHT, ACCENT_PRIMARY, ACCENT_SECONDARY, ACCENT_MUTED,
-    ACCENT_PALE, POSITIVE, NEGATIVE,
+    ACCENT_PALE, POSITIVE, NEGATIVE, NEGATIVE_BG,
     FONT_HEADING, FONT_BODY, CARD_RADIUS,
 )
 
@@ -123,8 +123,6 @@ _CSS = f"""
 </style>
 """
 
-# Need NEGATIVE_BG from theme — import it
-from ui.theme import NEGATIVE_BG
 
 
 def inject_css():


### PR DESCRIPTION
NEGATIVE_BG was used in the _CSS f-string (line 104) but only imported on line 127, after the f-string was already evaluated at module load time. Move it into the main import block.

https://claude.ai/code/session_01R5F2tJ52muwFi6pdcjA4CD